### PR TITLE
BeeLine执行脚本日志输出存在编码问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1280,14 +1280,17 @@ async def run_task(
             # 准备用于子进程的环境变量
             subprocess_env = os.environ.copy()
             subprocess_env.update(env_vars)
+            subprocess_env['PYTHONIOENCODING'] = 'utf-8'  # 设置Python IO编码
 
             process = subprocess.Popen(
                 ["python", script_thread.filename],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=subprocess_env, # 传递正确更新的环境变量
-                cwd="scripts" # 在子进程中设置工作目录
+                encoding='utf-8',  # 设置输出编码
+                errors='replace',  # 处理无法解码的字符
+                env=subprocess_env,
+                cwd="scripts"  # 设置工作目录
             )
             stdout, stderr = process.communicate()
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -45,13 +45,17 @@ def run_script(task_id):
         # 准备用于子进程的环境变量
         subprocess_env = os.environ.copy()
         subprocess_env.update(env_vars)
+        subprocess_env['PYTHONIOENCODING'] = 'utf-8'  # 设置Python IO编码
 
         process = subprocess.Popen(
             ["python", script_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env=subprocess_env
+            encoding='utf-8',  # 设置输出编码
+            errors='replace',  # 处理无法解码的字符
+            env=subprocess_env,
+            cwd="scripts"  # 设置工作目录
         )
         stdout, stderr = process.communicate()
 


### PR DESCRIPTION
tcl脚本日志（有编码问题）
![2025-06-06_111935](https://github.com/user-attachments/assets/96bf2eba-be07-415f-8c02-35d8519c132f)
tcl脚本日志（让AI修复了下）
![2025-06-06_112130](https://github.com/user-attachments/assets/a3f0809c-817c-428a-864a-fe1b5ff2ac8e)

tianfu脚本日志（有编码问题）
![2025-06-06_112259](https://github.com/user-attachments/assets/b12373ac-f428-4068-9436-0a27c261c1be)
无输出，但是控制台日志显示：UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcc in position 6: invalid continuation byte
tianfu脚本日志（让AI修复了下）
![2025-06-06_112440](https://github.com/user-attachments/assets/086fd4f4-e032-48b9-9c6b-4e10f506fad6)

